### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,18 +1,18 @@
-SparkFun_AS3935       KEYWORD1
+SparkFun_AS3935	KEYWORD1
 
 
-begin                 KEYWORD2
-powerDown             KEYWORD2
-indoorOutdoorSetting  KEYWORD2
-watchdogThreshold     KEYWORD2
-setNoiseLevel         KEYWORD2
-spikeReduction        KEYWORD2
-lightningThreshold    KEYWORD2
-clearStatistics       KEYWORD2
-readInterruptReg      KEYWORD2
-maskDisturber         KEYWORD2
-antennaTuning         KEYWORD2
-distanceToStorm       KEYWORD2
-displayOscillator     KEYWORD2
-tuneCap               KEYWORD2
-lightningEnergy       KEYWORD2
+begin	KEYWORD2
+powerDown	KEYWORD2
+indoorOutdoorSetting	KEYWORD2
+watchdogThreshold	KEYWORD2
+setNoiseLevel	KEYWORD2
+spikeReduction	KEYWORD2
+lightningThreshold	KEYWORD2
+clearStatistics	KEYWORD2
+readInterruptReg	KEYWORD2
+maskDisturber	KEYWORD2
+antennaTuning	KEYWORD2
+distanceToStorm	KEYWORD2
+displayOscillator	KEYWORD2
+tuneCap	KEYWORD2
+lightningEnergy	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords